### PR TITLE
Ask constValueOpt[T] directly instead of going through IsConst

### DIFF
--- a/squery/src/ba/sake/squery/sql.scala
+++ b/squery/src/ba/sake/squery/sql.scala
@@ -2,7 +2,6 @@ package ba.sake.squery
 
 import scala.language.implicitConversions
 import scala.compiletime.*
-import scala.compiletime.ops.any.*
 import scala.collection.mutable.ListBuffer
 import ba.sake.squery.write.*
 import ba.sake.squery.Query
@@ -18,9 +17,9 @@ type LiteralOrDynamicString = LiteralString | DynamicArg[String]
 // - dynamic strings are interpolated with ?, of course
 given string2LiteralString[T <: Singleton & String]: Conversion[T, LiteralOrDynamicString] with
   transparent inline def apply(value: T): LiteralOrDynamicString =
-    inline constValue[IsConst[T]] match
-      case true  => LiteralString(value)
-      case false => DynamicArg(value)(using SqlWrite[String])
+    inline constValueOpt[T] match
+      case Some(_) => LiteralString(value)
+      case _       => DynamicArg(value)(using SqlWrite[String])
 
 given sqlWrite2DynamicArg[T: SqlWrite]: Conversion[T, DynamicArg[T]] with
   def apply(value: T): DynamicArg[T] =


### PR DESCRIPTION
The existing code is unsound around `IsConst` and that unsoundness is fixed in https://github.com/scala/scala3/pull/26685 which causes the existing code to break, as evident by https://github.com/scala/scala3/issues/26816.
This PR fixes this by using `constValueOpt` instead of `IsConst`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of compile-time string literals.
  * Preserved correct handling of dynamically generated strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->